### PR TITLE
Fix: Validate poll_end timestamp to prevent expired and invalid values

### DIFF
--- a/anchor/programs/voting/src/lib.rs
+++ b/anchor/programs/voting/src/lib.rs
@@ -8,13 +8,29 @@ declare_id!("coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF");
 pub mod voting {
     use super::*;
 
-    pub fn initialize_poll(ctx: Context<InitializePoll>, 
-                            poll_id: u64,
-                            description: String,
-                            poll_start: u64,
-                            poll_end: u64) -> Result<()> {
-
+    pub fn initialize_poll(
+        ctx: Context<InitializePoll>,
+        poll_id: u64,
+        description: String,
+        poll_start: u64,
+        poll_end: u64,
+    ) -> Result<()> {
         let poll = &mut ctx.accounts.poll;
+
+        let clock = Clock::get()?; // Get the current blockchain time
+
+        // Ensure poll_end is in the future
+        require!(
+            poll_end > clock.unix_timestamp as u64,
+            VotingError::InvalidPollEndTimestamp
+        );
+
+        // Ensure poll_end is a valid Unix timestamp (not a random unsigned integer)
+        require!(
+            poll_end > 1700000000, // Roughly, any time after 2023
+            VotingError::InvalidUnixTimestamp
+        );
+
         poll.poll_id = poll_id;
         poll.description = description;
         poll.poll_start = poll_start;
@@ -23,10 +39,11 @@ pub mod voting {
         Ok(())
     }
 
-    pub fn initialize_candidate(ctx: Context<InitializeCandidate>, 
-                                candidate_name: String,
-                                _poll_id: u64
-                            ) -> Result<()> {
+    pub fn initialize_candidate(
+        ctx: Context<InitializeCandidate>,
+        candidate_name: String,
+        _poll_id: u64,
+    ) -> Result<()> {
         let candidate = &mut ctx.accounts.candidate;
         candidate.candidate_name = candidate_name;
         candidate.candidate_votes = 0;
@@ -41,7 +58,6 @@ pub mod voting {
         msg!("Votes: {}", candidate.candidate_votes);
         Ok(())
     }
-
 }
 
 #[derive(Accounts)]
@@ -53,19 +69,18 @@ pub struct Vote<'info> {
     #[account(
         seeds = [poll_id.to_le_bytes().as_ref()],
         bump
-      )]
+    )]
     pub poll: Account<'info, Poll>,
 
     #[account(
-      mut,
-      seeds = [poll_id.to_le_bytes().as_ref(), candidate_name.as_ref()],
-      bump
+        mut,
+        seeds = [poll_id.to_le_bytes().as_ref(), candidate_name.as_ref()],
+        bump
     )]
     pub candidate: Account<'info, Candidate>,
 
     pub system_program: Program<'info, System>,
 }
-
 
 #[derive(Accounts)]
 #[instruction(candidate_name: String, poll_id: u64)]
@@ -77,15 +92,15 @@ pub struct InitializeCandidate<'info> {
         mut,
         seeds = [poll_id.to_le_bytes().as_ref()],
         bump
-      )]
+    )]
     pub poll: Account<'info, Poll>,
 
     #[account(
-      init,
-      payer = signer,
-      space = 8 + Candidate::INIT_SPACE,
-      seeds = [poll_id.to_le_bytes().as_ref(), candidate_name.as_ref()],
-      bump
+        init,
+        payer = signer,
+        space = 8 + Candidate::INIT_SPACE,
+        seeds = [poll_id.to_le_bytes().as_ref(), candidate_name.as_ref()],
+        bump
     )]
     pub candidate: Account<'info, Candidate>,
     pub system_program: Program<'info, System>,
@@ -105,11 +120,11 @@ pub struct InitializePoll<'info> {
     #[account(mut)]
     pub signer: Signer<'info>,
     #[account(
-      init,
-      payer = signer,
-      space = 8 + Poll::INIT_SPACE,
-      seeds = [poll_id.to_le_bytes().as_ref()],
-      bump
+        init,
+        payer = signer,
+        space = 8 + Poll::INIT_SPACE,
+        seeds = [poll_id.to_le_bytes().as_ref()],
+        bump
     )]
     pub poll: Account<'info, Poll>,
     pub system_program: Program<'info, System>,
@@ -124,4 +139,13 @@ pub struct Poll {
     pub poll_start: u64,
     pub poll_end: u64,
     pub candidate_amount: u64,
+}
+
+#[error_code]
+pub enum VotingError {
+    #[msg("The poll_end timestamp must be in the future.")]
+    InvalidPollEndTimestamp,
+
+    #[msg("Invalid Unix Timestamp provided.")]
+    InvalidUnixTimestamp,
 }

--- a/anchor/tests/voting.spec.ts
+++ b/anchor/tests/voting.spec.ts
@@ -168,5 +168,142 @@ it("Successfully creates a poll with a valid future poll_end timestamp", async (
         assert.fail("Poll creation should have succeeded with a valid timestamp");
     }
 });
+describe("Voting", () => {
+  let context;
+  let provider;
+  let votingProgram: anchor.Program<Voting>;
+  let pollAddress: PublicKey;
+  let pinkAddress: PublicKey;
+  let blueAddress: PublicKey;
 
+  beforeAll(async () => {
+    context = await startAnchor('', [{ name: "voting", programId: PROGRAM_ID }], []);
+    provider = new BankrunProvider(context);
+    votingProgram = new anchor.Program<Voting>(
+      IDL,
+      provider,
+    );
+  });
+
+  it("initializes a poll", async () => {
+    await votingProgram.methods.initializePoll(
+      new anchor.BN(1),
+      "What is your favorite color?",
+      new anchor.BN(100),
+      new anchor.BN(1739370789),
+    ).rpc();
+
+    [pollAddress] = PublicKey.findProgramAddressSync(
+      [new anchor.BN(1).toArrayLike(Buffer, "le", 8)],
+      votingProgram.programId,
+    );
+
+    const poll = await votingProgram.account.poll.fetch(pollAddress);
+
+    console.log(poll);
+
+    expect(poll.pollId.toNumber()).toBe(1);
+    expect(poll.description).toBe("What is your favorite color?");
+    expect(poll.pollStart.toNumber()).toBe(100);
+  });
+
+  it("initializes candidates", async () => {
+    await votingProgram.methods.initializeCandidate(
+      "Pink",
+      new anchor.BN(1),
+    ).rpc();
+    await votingProgram.methods.initializeCandidate(
+      "Blue",
+      new anchor.BN(1),
+    ).rpc();
+
+    [pinkAddress] = PublicKey.findProgramAddressSync(
+      [new anchor.BN(1).toArrayLike(Buffer, "le", 8), Buffer.from("Pink")],
+      votingProgram.programId,
+    );
+    const pinkCandidate = await votingProgram.account.candidate.fetch(pinkAddress);
+    console.log(pinkCandidate);
+    expect(pinkCandidate.candidateVotes.toNumber()).toBe(0);
+    expect(pinkCandidate.candidateName).toBe("Pink");
+
+    [blueAddress] = PublicKey.findProgramAddressSync(
+      [new anchor.BN(1).toArrayLike(Buffer, "le", 8), Buffer.from("Blue")],
+      votingProgram.programId,
+    );
+    const blueCandidate = await votingProgram.account.candidate.fetch(blueAddress);
+    console.log(blueCandidate);
+    expect(blueCandidate.candidateVotes.toNumber()).toBe(0);
+    expect(blueCandidate.candidateName).toBe("Blue");
+  });
+
+  it("vote candidates", async () => {
+    await votingProgram.methods.vote(
+      "Pink",
+      new anchor.BN(1),
+    ).rpc();
+    await votingProgram.methods.vote(
+      "Blue",
+      new anchor.BN(1),
+    ).rpc();
+    await votingProgram.methods.vote(
+      "Pink",
+      new anchor.BN(1),
+    ).rpc();
+
+    const pinkCandidate = await votingProgram.account.candidate.fetch(pinkAddress);
+    console.log(pinkCandidate);
+    expect(pinkCandidate.candidateVotes.toNumber()).toBe(2);
+    expect(pinkCandidate.candidateName).toBe("Pink");
+
+    const blueCandidate = await votingProgram.account.candidate.fetch(blueAddress);
+    console.log(blueCandidate);
+    expect(blueCandidate.candidateVotes.toNumber()).toBe(1);
+    expect(blueCandidate.candidateName).toBe("Blue");
+  });
+
+  it("Fails to create a poll with an expired poll_end timestamp", async () => {
+    try {
+      await votingProgram.methods.initializePoll(
+        new anchor.BN(1),
+        "Expired Poll",
+        new anchor.BN(1700000000), // Some past timestamp
+        new anchor.BN(1700000100)  // Expired timestamp
+      ).rpc();
+    } catch (err) {
+      expect(err.message).toContain("The poll_end timestamp must be in the future");
+      return;
+    }
+    expect.fail("Poll creation should have failed with expired poll_end timestamp");
+  });
+
+  it("Fails to create a poll with an invalid Unix timestamp", async () => {
+    try {
+      await votingProgram.methods.initializePoll(
+        new anchor.BN(2),
+        "Invalid Timestamp Poll",
+        new anchor.BN(1700000000), 
+        new anchor.BN(99999)  // Invalid timestamp (not a real Unix timestamp)
+      ).rpc();
+    } catch (err) {
+      expect(err.message).toContain("Invalid Unix Timestamp provided");
+      return;
+    }
+    expect.fail("Poll creation should have failed with invalid poll_end timestamp");
+  });
+
+  it("Successfully creates a poll with a valid future poll_end timestamp", async () => {
+    try {
+      const tx = await votingProgram.methods.initializePoll(
+        new anchor.BN(3),
+        "Valid Poll",
+        new anchor.BN(1700000000), 
+        new anchor.BN(Math.floor(Date.now() / 1000) + 3600) // Current time + 1 hour
+      ).rpc();
+
+      console.log("Poll created successfully, Transaction:", tx);
+    } catch (err) {
+      expect.fail("Poll creation should have succeeded with a valid timestamp");
+    }
+  });
+});
 });


### PR DESCRIPTION
**issue: Validate poll_start & poll_end Timestamp During Poll Initialization**
Registered Email: 2023kucp1091@iiitkota.ac.in
Issue Overview
Currently, the initialize_poll function does not enforce validation on the poll_end timestamp. This allows the creation of polls with an expiration timestamp that is already in the past, leading to an inconsistent state. Additionally, there is no verification to ensure that the provided timestamp adheres to a valid Unix timestamp format, which could introduce potential errors.

Technical Solution
Validation in initialize_poll():

Introduced a check to ensure poll_end is strictly greater than the current block timestamp (Clock::get()?.unix_timestamp).
Added type constraints to ensure that the provided timestamp is a valid unsigned integer and falls within the Unix epoch range.
Test Coverage Enhancements (voting.test.ts):

Boundary Case: Attempt to initialize a poll with poll_end equal to or less than the current time (should fail).
Invalid Input Handling: Attempt to pass a non-Unix timestamp (should fail).
Successful Case: Create a poll with a valid future poll_end timestamp (should pass).
Implementation Details
Used Solana’s Clock program to fetch the current block time dynamically instead of relying on external assumptions.
Ensured error messages are descriptive to aid debugging (Poll end timestamp must be in the future).
Impact
Prevents accidental or intentional creation of expired polls.
Ensures all created polls adhere to a valid Unix timestamp standard.
Improves smart contract robustness by rejecting malformed inputs.
Bounty Submission
Issue Overview
Currently, the initialize_poll function does not enforce validation on the poll_end timestamp. This allows the creation of polls with an expiration timestamp that is already in the past, leading to an inconsistent state. Additionally, there is no verification to ensure that the provided timestamp adheres to a valid Unix timestamp format, which could introduce potential errors.

Technical Solution
Validation in initialize_poll():

Introduced a check to ensure poll_end is strictly greater than the current block timestamp (Clock::get()?.unix_timestamp).
Added type constraints to ensure that the provided timestamp is a valid unsigned integer and falls within the Unix epoch range.
Test Coverage Enhancements (voting.test.ts):

Boundary Case: Attempt to initialize a poll with poll_end equal to or less than the current time (should fail).
Invalid Input Handling: Attempt to pass a non-Unix timestamp (should fail).
Successful Case: Create a poll with a valid future poll_end timestamp (should pass).
Implementation Details
Used Solana’s Clock program to fetch the current block time dynamically instead of relying on external assumptions.
Ensured error messages are descriptive to aid debugging (Poll end timestamp must be in the future).
Impact
Prevents accidental or intentional creation of expired polls.
Ensures all created polls adhere to a valid Unix timestamp standard.
Improves smart contract robustness by rejecting malformed inputs.

